### PR TITLE
Add missing serialization and remove unused bundle parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,7 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_utilitarian"
-version = "0.2.0"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ca22b92391a5277c3eafbd7134ef3fb3e7e32cfa1ee144f7d9cbcbe42a515d"
 dependencies = [
  "bevy",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,7 @@ dependencies = [
  "bevy_xpbd_3d",
  "bytemuck",
  "rand",
+ "serde",
 ]
 
 [[package]]
@@ -1013,8 +1014,6 @@ dependencies = [
 [[package]]
 name = "bevy_utilitarian"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b93ae504168501a2ff97b14dd85395a7507a3147923f2264cc63aa6f0adf6d"
 dependencies = [
  "bevy",
  "rand",
@@ -3222,18 +3221,18 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bevy", "gamedev", "particles", "graphics"]
 bevy = "0.12.0"
 bytemuck = "1.14.3"
 rand = "0.8.5"
-bevy_utilitarian = { version = "0.2.0", path = "../bevy_utilitarian" }
+bevy_utilitarian = { version = "0.3.0" }
 bevy_xpbd_3d = { version = "0.3.0", optional = true }
 serde = { version = "1.0.197", features = ["derive"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,9 @@ keywords = ["bevy", "gamedev", "particles", "graphics"]
 bevy = "0.12.0"
 bytemuck = "1.14.3"
 rand = "0.8.5"
-bevy_utilitarian = { version = "0.2.0" }
+bevy_utilitarian = { version = "0.2.0", path = "../bevy_utilitarian" }
 bevy_xpbd_3d = { version = "0.3.0", optional = true }
+serde = { version = "1.0.197", features = ["derive"] }
 
 [features]
 default = ["physics_xbpd"]

--- a/examples/pbr.rs
+++ b/examples/pbr.rs
@@ -1,6 +1,6 @@
 use bevy::{core_pipeline::bloom::BloomSettings, prelude::*};
 use bevy_firework::{
-    core::{ParticleSpawnerBundle, ParticleSpawnerSettings},
+    core::{BlendMode, ParticleSpawnerBundle, ParticleSpawnerSettings},
     emission_shape::EmissionShape,
     plugin::ParticleSystemPlugin,
 };
@@ -64,13 +64,12 @@ fn setup(
                     (0.1, Color::rgba(0.6, 0.3, 0., 0.5).into()),
                     (1., Color::rgba(0.6, 0.3, 0., 0.0).into()),
                 ]),
-                blend_mode: AlphaMode::Blend,
+                blend_mode: BlendMode::Blend,
                 linear_drag: 0.7,
                 pbr: true,
                 acceleration: Vec3::new(0., 0.3, 0.),
                 ..default()
             },
-            &mut meshes,
         ))
         .insert(Transform::from_xyz(0., 0.1, 0.));
     // cube

--- a/examples/sparks.rs
+++ b/examples/sparks.rs
@@ -1,12 +1,11 @@
-use std::f32::consts::PI;
-
 use bevy::{core_pipeline::bloom::BloomSettings, prelude::*};
 use bevy_firework::{
-    core::{ParticleSpawnerBundle, ParticleSpawnerSettings},
+    core::{BlendMode, ParticleSpawnerBundle, ParticleSpawnerSettings},
     emission_shape::EmissionShape,
     plugin::ParticleSystemPlugin,
 };
 use bevy_utilitarian::prelude::*;
+use std::f32::consts::PI;
 
 fn main() {
     App::new()
@@ -75,12 +74,11 @@ fn setup(
                     (0.9, Color::rgba(0.3, 0.3, 0.3, 1.).into()),
                     (1., Color::rgba(0.1, 0.1, 0.1, 0.).into()),
                 ]),
-                blend_mode: AlphaMode::Blend,
+                blend_mode: BlendMode::Blend,
                 linear_drag: 0.1,
                 pbr: false,
                 ..default()
             },
-            &mut meshes,
         ))
         .insert(Transform::from_xyz(0., 0.1, 0.));
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -6,11 +6,13 @@ use bevy_xpbd_3d::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
+pub const DEFAULT_MESH: Handle<Mesh> =
+    Handle::weak_from_u128(164408926256276437310893021157813788765);
+
 /// Mirrors AlphaMode, but implements serialize and deserialize
 #[derive(Debug, Clone, Copy, PartialEq, Reflect, Serialize, Deserialize)]
 pub enum BlendMode {
     Opaque,
-    Mask(f32),
     Blend,
     Premultiplied,
     Add,
@@ -21,11 +23,22 @@ impl From<BlendMode> for AlphaMode {
     fn from(value: BlendMode) -> Self {
         match value {
             BlendMode::Opaque => AlphaMode::Opaque,
-            BlendMode::Mask(v) => AlphaMode::Mask(v),
             BlendMode::Blend => AlphaMode::Blend,
             BlendMode::Premultiplied => AlphaMode::Premultiplied,
             BlendMode::Add => AlphaMode::Add,
             BlendMode::Multiply => AlphaMode::Multiply,
+        }
+    }
+}
+
+impl From<BlendMode> for u32 {
+    fn from(value: BlendMode) -> Self {
+        match value {
+            BlendMode::Opaque => 0,
+            BlendMode::Blend => 2,
+            BlendMode::Premultiplied => 3,
+            BlendMode::Add => 4,
+            BlendMode::Multiply => 5,
         }
     }
 }
@@ -118,6 +131,7 @@ impl From<&ParticleSpawnerSettings> for ParticleSpawnerData {
 pub struct ParticleSpawnerBundle {
     spatial: SpatialBundle,
     settings: ParticleSpawnerSettings,
+    mesh: Handle<Mesh>,
     name: Name,
 }
 
@@ -126,6 +140,7 @@ impl ParticleSpawnerBundle {
         Self {
             settings,
             spatial: SpatialBundle::default(),
+            mesh: DEFAULT_MESH.clone(),
             name: Name::new("Particle System"),
         }
     }
@@ -283,6 +298,13 @@ pub fn propagate_particle_spawner_modifier(
             }
         }
     }
+}
+
+pub fn setup_default_mesh(mut meshes: ResMut<Assets<Mesh>>) {
+    meshes.insert(
+        DEFAULT_MESH.clone(),
+        Mesh::from(shape::Quad::new(Vec2::new(1., 1.))),
+    );
 }
 
 #[cfg(feature = "physics_xpbd")]

--- a/src/emission_shape.rs
+++ b/src/emission_shape.rs
@@ -1,8 +1,9 @@
 use bevy::prelude::*;
 use bevy_utilitarian::geometric::pitchyaw::PitchYaw;
+use serde::{Deserialize, Serialize};
 use std::f32::consts::PI;
 
-#[derive(Default, Clone, Copy, Debug, Reflect)]
+#[derive(Default, Clone, Copy, Debug, Reflect, Serialize, Deserialize)]
 pub enum EmissionShape {
     #[default]
     Point,

--- a/src/particles.wgsl
+++ b/src/particles.wgsl
@@ -23,9 +23,15 @@
 struct Vertex {
     @location(3) i_pos_scale: vec4<f32>,
     @location(4) i_color: vec4<f32>,
-    @location(5) pbr: u32,
     @builtin(vertex_index) index: u32,
 };
+
+struct FireworkUniform {
+    alpha_mode: u32,
+    pbr: u32,
+}
+
+@group(1) @binding(0) var<uniform> firework_uniform: FireworkUniform;
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
@@ -33,7 +39,6 @@ struct VertexOutput {
     @location(1) world_normal: vec3<f32>,
     @location(2) color: vec4<f32>,
     @location(3) uv: vec2<f32>,
-    @location(4) pbr: u32,
 };
 
 fn extract_rot(bigmat: mat4x4<f32>) -> mat3x3<f32> {
@@ -66,7 +71,6 @@ fn vertex(vertex: Vertex) -> VertexOutput {
     out.position = position_world_to_clip(position_world);
     out.color = vertex.i_color;
     out.world_normal = direction_view_to_world(vec3(0., 0., 1.));
-    out.pbr = vertex.pbr;
     out.uv = uvs[vertex.index];
 
     return out;
@@ -83,7 +87,7 @@ fn fragment(in: VertexOutput, @builtin(front_facing) is_front: bool) -> @locatio
         discard;
     }
 
-    if in.pbr == 0u {
+    if firework_uniform.pbr == 0u {
         return color;
     } else {
         return pbr_stuff(color, in.position, in.world_position, in.world_normal, in.uv, is_front);
@@ -135,7 +139,9 @@ fn pbr_stuff(
         vec3(0.,0.,1.),
 #endif
 #endif
+#ifdef VERTEX_UVS
         uv,
+#endif
         view.mip_bias,
     );
     pbr_input.V = fns::calculate_view(world_position, pbr_input.is_orthographic);

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,3 +1,5 @@
+use crate::core::setup_default_mesh;
+
 use super::{
     core::{
         create_spawner_data, propagate_particle_spawner_modifier, spawn_particles,
@@ -27,6 +29,7 @@ impl Plugin for ParticleSystemPlugin {
         app //
             .register_type::<ParticleSpawnerSettings>()
             .add_plugins(render::CustomMaterialPlugin)
+            .add_systems(Startup, setup_default_mesh)
             .add_systems(
                 Update,
                 (

--- a/src/render.rs
+++ b/src/render.rs
@@ -70,7 +70,7 @@ impl ExtractComponent for ParticleSpawnerData {
         let (data, settings) = item;
         Some(ParticleMaterialData {
             particles: data.particles.iter().map(|p| p.into()).collect(),
-            alpha_mode: settings.blend_mode,
+            alpha_mode: settings.blend_mode.into(),
         })
     }
 }


### PR DESCRIPTION
As an remnant of my first implementation of this plugin, the `ParticleSpawnerBundle` required `&mut Assets<Mesh>`. This is because I used to use mesh instancing to draw particles.

Since I'm now using a hardcoded billboarded quad, we do not need to require a mesh, and we can replace the specialized mesh pipeline with a specialized render pipeline.

This PR also introduces an uniform buffer for per-system parameters such as `pbr`, which were previously unnecessarily bundled with each particle's data.