### PR TITLE
Particle collision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,7 @@ dependencies = [
  "bevy_tasks",
  "bevy_utils",
  "bytemuck",
+ "serde",
 ]
 
 [[package]]
@@ -658,6 +659,7 @@ dependencies = [
  "bevy_math",
  "bevy_reflect",
  "bevy_utils",
+ "serde",
  "thiserror",
 ]
 
@@ -964,6 +966,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_utils",
  "crossbeam-channel",
+ "serde",
  "thiserror",
 ]
 
@@ -978,6 +981,7 @@ dependencies = [
  "bevy_hierarchy",
  "bevy_math",
  "bevy_reflect",
+ "serde",
  "thiserror",
 ]
 
@@ -1065,6 +1069,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_utils",
  "raw-window-handle",
+ "serde",
 ]
 
 [[package]]
@@ -1094,9 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_xpbd_3d"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35590e6cb2860b6a548a37e776dd36ae1aee5c669169caa130f0038a0453ade2"
+version = "0.3.2"
 dependencies = [
  "bevy",
  "bevy_xpbd_derive",
@@ -1108,13 +1111,12 @@ dependencies = [
  "nalgebra",
  "parry3d",
  "parry3d-f64",
+ "serde",
 ]
 
 [[package]]
 name = "bevy_xpbd_derive"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1ef1d5e328abe1b76df974245f78e17fd17867583883d5e77444c6a8223a64"
 dependencies = [
  "quote",
  "syn 2.0.49",
@@ -2471,6 +2473,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
+ "serde",
  "simba",
  "typenum",
 ]
@@ -2579,6 +2582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -2836,6 +2840,7 @@ dependencies = [
  "num-traits",
  "rayon",
  "rustc-hash",
+ "serde",
  "simba",
  "slab",
  "smallvec",
@@ -2858,6 +2863,7 @@ dependencies = [
  "num-traits",
  "rayon",
  "rustc-hash",
+ "serde",
  "simba",
  "slab",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,15 +7,20 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/mbrea-c/bevy_firework"
 description = "CPU-driven, batch-rendered particle system for the Bevy game engine"
 keywords = ["bevy", "gamedev", "particles", "graphics"]
+resolver = "2"
 
 [dependencies]
 bevy = "0.12.0"
 bytemuck = "1.14.3"
 rand = "0.8.5"
 bevy_utilitarian = { version = "0.3.0" }
-bevy_xpbd_3d = { version = "0.3.0", optional = true }
+bevy_xpbd_3d = { version = "0.3.0", features = ["serialize"], optional = true }
 serde = { version = "1.0.197", features = ["derive"] }
 
 [features]
-default = ["physics_xbpd"]
-physics_xbpd = ["dep:bevy_xpbd_3d"]
+default = ["physics_xpbd"]
+physics_xpbd = ["dep:bevy_xpbd_3d"]
+
+[[example]]
+name = "collision"
+required-features = ["physics_xpbd"]

--- a/examples/collision.rs
+++ b/examples/collision.rs
@@ -1,0 +1,151 @@
+use bevy::{core_pipeline::bloom::BloomSettings, prelude::*};
+use bevy_firework::{
+    core::{BlendMode, ParticleCollisionSettings, ParticleSpawnerBundle, ParticleSpawnerSettings},
+    emission_shape::EmissionShape,
+    plugin::ParticleSystemPlugin,
+};
+use bevy_utilitarian::prelude::*;
+use bevy_xpbd_3d::prelude::*;
+use std::f32::consts::PI;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(PhysicsPlugins::default())
+        .add_plugins(ParticleSystemPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, adjust_time_scale)
+        .run();
+}
+
+/// set up a simple 3D scene
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // spawn text
+    commands.spawn(TextBundle {
+        text: Text {
+            sections: vec![TextSection {
+                value: "Press Space to toggle slow motion".to_string(),
+                style: TextStyle {
+                    font_size: 40.0,
+                    color: Color::WHITE,
+                    ..default()
+                },
+            }],
+            ..Default::default()
+        },
+        transform: Transform::from_xyz(-4.0, 4.0, 0.0),
+        ..Default::default()
+    });
+
+    // circular base
+    commands
+        .spawn(PbrBundle {
+            mesh: meshes.add(shape::Box::new(8., 1., 8.).into()),
+            material: materials.add(Color::WHITE.into()),
+            transform: Transform::from_translation(Vec3::new(0., -0.5, 0.)),
+            ..default()
+        })
+        .insert(Collider::cuboid(8., 1., 8.));
+    commands
+        .spawn(ParticleSpawnerBundle::from_settings(
+            ParticleSpawnerSettings {
+                rate: 100.0,
+                one_shot: false,
+                emission_shape: EmissionShape::Circle {
+                    normal: Vec3::Y,
+                    radius: 0.3,
+                },
+                lifetime: RandF32::constant(6.75),
+                initial_velocity: RandVec3 {
+                    magnitude: RandF32 { min: 6., max: 8. },
+                    direction: Vec3::Y,
+                    spread: 30. / 180. * PI,
+                },
+                inherit_parent_velocity: true,
+                initial_scale: RandF32 {
+                    min: 0.02,
+                    max: 0.08,
+                },
+                scale_curve: ParamCurve::constant(1.),
+                linear_drag: 0.15,
+                color: Gradient::linear(vec![
+                    (0., Color::rgba(300., 100., 1., 1.).into()),
+                    (0.7, Color::rgba(3., 1., 1., 1.).into()),
+                    (0.8, Color::rgba(1., 0.3, 0.3, 1.).into()),
+                    (0.9, Color::rgba(0.3, 0.3, 0.3, 1.).into()),
+                    (1., Color::rgba(0.1, 0.1, 0.1, 0.).into()),
+                ]),
+                blend_mode: BlendMode::Blend,
+                pbr: true,
+                collision_settings: Some(ParticleCollisionSettings {
+                    restitution: 0.6,
+                    friction: 0.2,
+                    filter: SpatialQueryFilter::default(),
+                }),
+                ..default()
+            },
+        ))
+        .insert(Transform {
+            translation: Vec3::new(5., 0.5, 0.),
+            rotation: Quat::from_rotation_z(PI / 4.),
+            ..default()
+        });
+
+    // angled cube
+    commands
+        .spawn(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+            transform: Transform {
+                translation: Vec3::new(0., 0.5, 0.),
+                rotation: Quat::from_rotation_x(PI / 4.) * Quat::from_rotation_y(PI / 4.),
+                ..default()
+            },
+            ..default()
+        })
+        .insert(Collider::cuboid(1., 1., 1.));
+
+    // light
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            intensity: 1500.0,
+            shadows_enabled: true,
+            ..default()
+        },
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..default()
+    });
+    // camera
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
+            camera: Camera {
+                hdr: true,
+
+                ..default()
+            },
+            ..default()
+        },
+        BloomSettings::default(),
+    ));
+}
+
+fn adjust_time_scale(
+    mut slowmo: Local<bool>,
+    mut time: ResMut<Time<Virtual>>,
+    input: Res<Input<KeyCode>>,
+) {
+    if input.just_pressed(KeyCode::Space) {
+        *slowmo = !*slowmo;
+    }
+
+    if *slowmo {
+        time.set_relative_speed(0.05);
+    } else {
+        time.set_relative_speed(1.0);
+    }
+}

--- a/src/core.rs
+++ b/src/core.rs
@@ -417,7 +417,7 @@ fn particle_collision(
             false,
             collision_settings.filter.clone(),
         ) {
-            pos = pos + vel.normalize_or_zero() * hit.time_of_impact;
+            pos += vel.normalize_or_zero() * hit.time_of_impact;
             let vel_reject = vel.reject_from(hit.normal);
             let vel_project = vel.project_onto(hit.normal);
             let friction_dv =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,5 @@ pub mod core;
 pub mod emission_shape;
 pub mod plugin;
 mod render;
+
+pub use bevy_utilitarian;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -7,7 +7,7 @@ use super::{
     },
     render,
 };
-use bevy::{asset::load_internal_asset, prelude::*};
+use bevy::{asset::load_internal_asset, prelude::*, transform::TransformSystem};
 
 #[cfg(feature = "physics_xpbd")]
 use super::core::sync_parent_velocity;
@@ -39,10 +39,14 @@ impl Plugin for ParticleSystemPlugin {
                     sync_spawner_data,
                     #[cfg(feature = "physics_xpbd")]
                     sync_parent_velocity,
-                    spawn_particles,
-                    update_particles,
                 )
                     .chain(),
+            )
+            .add_systems(
+                PostUpdate,
+                (spawn_particles, update_particles)
+                    .chain()
+                    .after(TransformSystem::TransformPropagate),
             );
     }
 }


### PR DESCRIPTION
This PR adds optional particle collision with arbitrary `bevy_xpbd` colliders. It is behind the `physics_xpbd` feature flag, so it can be compiled out.

It also parallelizes updates of particle systems, which can improve performance when there are many different particle systems running at once.