### PR TITLE
Ensure uniform buffer is 16-byte aligned

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ physics data for particle collision, simplified particle system animation).
 - Configurable integration with Bevy's PBR rendering (i.e. particles can receive
   shadows, are affected by fog and lighting changes).
 - Particle collision with arbitrary `bevy_xpbd` colliders.
+- WASM and WebGL compatible.
 - Soft particle edges.
 - Animated properties: certain parameters can be defined as a custom curve to
   express changes over a particle's lifetime:

--- a/src/particles.wgsl
+++ b/src/particles.wgsl
@@ -29,6 +29,7 @@ struct Vertex {
 struct FireworkUniform {
     alpha_mode: u32,
     pbr: u32,
+    _wasm_padding: vec2<f32>,
 }
 
 @group(1) @binding(0) var<uniform> firework_uniform: FireworkUniform;

--- a/src/render.rs
+++ b/src/render.rs
@@ -75,6 +75,7 @@ impl ExtractComponent for ParticleSpawnerData {
             FireworkUniform {
                 alpha_mode: settings.blend_mode.into(),
                 pbr: settings.pbr.into(),
+                _wasm_padding: Vec2::ZERO,
             },
         ))
     }
@@ -258,6 +259,7 @@ pub struct FireworkUniformBindgroup {
 pub struct FireworkUniform {
     alpha_mode: u32,
     pbr: u32,
+    _wasm_padding: Vec2,
 }
 
 pub fn prepare_firework_bindgroup(


### PR DESCRIPTION
WebGL requires that uniform buffers are 16-byte aligned. This PR allows `bevy_firework` to be used for wasm targets by adding the missing padding.


Thanks to `bestranar` for providing the patch! 