### PR TITLE
Add setting for initializing in a disabled state

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -85,6 +85,8 @@ pub struct ParticleSpawnerSettings {
     /// If Some, particles will collide with the scene according to the provided parameters
     /// If None, no particle collision will occur.
     pub collision_settings: Option<ParticleCollisionSettings>,
+    /// Whether to initialize the spawner in a disabled state
+    pub starts_disabled: bool,
 }
 
 impl Default for ParticleSpawnerSettings {
@@ -108,6 +110,7 @@ impl Default for ParticleSpawnerSettings {
             collision_settings: None,
             fade_edge: 0.7,
             fade_scene: 1.,
+            starts_disabled: false,
         }
     }
 }
@@ -154,7 +157,7 @@ impl Default for ParticleSpawnerData {
 impl From<&ParticleSpawnerSettings> for ParticleSpawnerData {
     fn from(settings: &ParticleSpawnerSettings) -> Self {
         Self {
-            enabled: true,
+            enabled: !settings.starts_disabled,
             cooldown: Timer::from_seconds(1. / settings.rate, TimerMode::Repeating),
             particles: vec![],
             parent_velocity: Vec3::ZERO,


### PR DESCRIPTION
Fixes #10.

I was doing this in a local fork anyway to test an app, so I figured I might as well open a PR.

This does what is described in https://github.com/mbrea-c/bevy_firework/issues/10#issuecomment-2023331426.

Side note: It's not totally clear to me why `ParticleSpawnerData` is not just included in `ParticleSpawnerBundle`. I experimented with removing it here: https://github.com/rparrett/bevy_firework/commit/d33aa0a5c0e7de70f6917bba224db88e53f78fb7 and at a glance, things don't seem broken.