### PR TITLE
Allow configuration of schedule in which particles update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_firework"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "avian3d",
  "bevy",

--- a/examples/collision.rs
+++ b/examples/collision.rs
@@ -18,7 +18,7 @@ fn main() {
     #[cfg(target_arch = "wasm32")]
     app.insert_resource(Msaa::Off);
 
-    app.add_plugins(ParticleSystemPlugin)
+    app.add_plugins(ParticleSystemPlugin::default())
         .add_systems(Startup, setup)
         .add_systems(Update, adjust_time_scale)
         .run();

--- a/examples/pbr.rs
+++ b/examples/pbr.rs
@@ -20,7 +20,7 @@ fn main() {
 
     // The particle system plugin must be added **after** any changes
     // to the MSAA setting.
-    app.add_plugins(ParticleSystemPlugin)
+    app.add_plugins(ParticleSystemPlugin::default())
         .add_systems(Startup, setup)
         .add_systems(Update, (adjust_time_scale, rotate_point_light));
     #[cfg(feature = "physics_avian")]

--- a/examples/sparks.rs
+++ b/examples/sparks.rs
@@ -18,7 +18,7 @@ fn main() {
 
     // The particle system plugin must be added **after** any changes
     // to the MSAA setting.
-    app.add_plugins(ParticleSystemPlugin)
+    app.add_plugins(ParticleSystemPlugin::default())
         .add_systems(Startup, setup)
         .add_systems(Update, adjust_time_scale);
 

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -25,7 +25,7 @@ fn main() {
 
     // The particle system plugin must be added **after** any changes
     // to the MSAA setting.
-    app.add_plugins(ParticleSystemPlugin)
+    app.add_plugins(ParticleSystemPlugin::default())
         .init_resource::<DebugInfo>()
         .add_systems(Startup, setup)
         .add_systems(

--- a/examples/stress_test_collision.rs
+++ b/examples/stress_test_collision.rs
@@ -27,7 +27,7 @@ fn main() {
 
     // The particle system plugin must be added **after** any changes
     // to the MSAA setting.
-    app.add_plugins(ParticleSystemPlugin)
+    app.add_plugins(ParticleSystemPlugin::default())
         .init_resource::<DebugInfo>()
         .add_systems(Startup, setup)
         .add_systems(


### PR DESCRIPTION
If using `FixedUpdate` for simulation systems (e.g. in multiplayer games) we want to be able to update particles in `FixedUpdate` as well to prevent janky-looking particle sim. This PR allows the particle update schedule to be configured at Plugin level.