### PR TITLE
Fix delta_secs issue when not compiling with physics_avian feature

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -291,7 +291,7 @@ pub fn update_particles(
                         };
                     #[cfg(not(feature = "physics_avian"))]
                     let (new_pos, new_vel) = (
-                        particle.position + particle.velocity * time.delta_seconds(),
+                        particle.position + particle.velocity * time.delta_secs(),
                         particle.velocity,
                     );
 


### PR DESCRIPTION
This one's pretty self explanatory. One change was just missed. 😄