### PR TITLE
Update avian to 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,12 +290,15 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "avian3d"
-version = "0.1.2"
-source = "git+https://github.com/Jondolf/avian.git?rev=52cbcecce0fd05a65005ab6935ebeb231373c2c6#52cbcecce0fd05a65005ab6935ebeb231373c2c6"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b563e53203ce50ce39c221a7e0b1f73b8fc2b4aa65439b436700c4ee1e85547a"
 dependencies = [
  "avian_derive",
  "bevy",
+ "bevy_heavy",
  "bevy_math",
+ "bevy_transform_interpolation",
  "bitflags 2.6.0",
  "derive_more",
  "fxhash",
@@ -309,8 +312,9 @@ dependencies = [
 
 [[package]]
 name = "avian_derive"
-version = "0.1.0"
-source = "git+https://github.com/Jondolf/avian.git?rev=52cbcecce0fd05a65005ab6935ebeb231373c2c6#52cbcecce0fd05a65005ab6935ebeb231373c2c6"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7a3e79be90cc09d87a43e1d9bf4f41c896f97cbd7d4fe4c3b79749106d285"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -693,6 +697,17 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+]
+
+[[package]]
+name = "bevy_heavy"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f85619a206875db57b0213dc5242b51f1be748663cd5f8f99f78d2a6a108dabf"
+dependencies = [
+ "bevy_math",
+ "bevy_reflect",
+ "serde",
 ]
 
 [[package]]
@@ -1167,6 +1182,16 @@ dependencies = [
  "bevy_math",
  "bevy_reflect",
  "derive_more",
+ "serde",
+]
+
+[[package]]
+name = "bevy_transform_interpolation"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fcad6974fb74cab07425c4f3d3af78876966b4525c3aec5c0d56ae8511a946a"
+dependencies = [
+ "bevy",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,7 @@ bytemuck = "1.14.3"
 rand = "0.8.5"
 bevy_utilitarian = "0.6"
 serde = { version = "1.0", features = ["derive"] }
-
-[dependencies.avian3d]
-# version = "0.1"
-git = "https://github.com/Jondolf/avian.git"
-rev = "52cbcecce0fd05a65005ab6935ebeb231373c2c6"
-features = ["serialize"]
-optional = true
+avian3d = { version = "0.2", features = ["serialize"], optional = true }
 
 [features]
 default = ["physics_avian"]

--- a/src/core.rs
+++ b/src/core.rs
@@ -390,7 +390,7 @@ fn particle_collision(
             true,
             &collision_settings.filter,
         ) {
-            if hit.time_of_impact == 0. {
+            if hit.distance == 0. {
                 let mut normal = hit.normal;
                 if normal == Vec3::ZERO {
                     if vel != Vec3::ZERO {
@@ -401,7 +401,7 @@ fn particle_collision(
                 }
                 pos += vel.length().max(1.) * normal * delta;
             } else {
-                pos += vel.normalize_or_zero() * hit.time_of_impact;
+                pos += vel.normalize_or_zero() * hit.distance;
                 let vel_reject = vel.reject_from(hit.normal);
                 let vel_project = vel.project_onto(hit.normal);
                 let friction_dv =
@@ -410,7 +410,7 @@ fn particle_collision(
                     - (friction_dv * vel_reject.normalize_or_zero())
                     - collision_settings.restitution * vel_project;
                 pos += hit.normal * 0.0001;
-                delta = (delta - hit.time_of_impact).clamp(0., orig_delta);
+                delta = (delta - hit.distance).clamp(0., orig_delta);
             }
         } else {
             pos += vel * delta;


### PR DESCRIPTION
When trying the examples in my project, the physics didn't work. This turned out to be because I was on avian 0.2. This PR updates avian to 0.2 which fixes the issue for me. Should this be added to the table in the README?

https://github.com/mbrea-c/bevy_firework/pull/25 mentioned this was blocking cutting a release, hopefully it is possible now with avian 0.2 released!

The `time_of_impact` -> `distance` change is documented in https://joonaa.dev/blog/07/avian-0-2 in **Other Improvements**.
