### PR TITLE
feat: add spawn_transform_mode setting and one_shot particles example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ default = ["physics_avian"]
 physics_avian = ["dep:avian3d"]
 
 [[example]]
+name = "one_shot"
+required-features = ["physics_avian"]
+
+[[example]]
 name = "collision"
 required-features = ["physics_avian"]
 

--- a/examples/one_shot.rs
+++ b/examples/one_shot.rs
@@ -1,0 +1,221 @@
+use avian3d::prelude::{
+    Collider, CollisionEventsEnabled, Collisions, Friction, LinearVelocity, OnCollisionStart,
+    Position, Restitution, RigidBody, Rotation,
+};
+use bevy::{
+    core_pipeline::{bloom::Bloom, prepass::DepthPrepass},
+    prelude::*,
+};
+use bevy_firework::{
+    core::{BlendMode, ParticleSpawner, SpawnTransformMode},
+    curve::{FireworkCurve, FireworkGradient},
+    emission_shape::EmissionShape,
+    plugin::ParticleSystemPlugin,
+};
+use bevy_utilitarian::prelude::*;
+
+fn main() {
+    let mut app = App::new();
+    app.add_plugins(DefaultPlugins);
+
+    app.add_plugins(ParticleSystemPlugin::default())
+        .add_systems(Startup, setup)
+        .add_systems(Update, (adjust_time_scale, rotate_point_light));
+    #[cfg(feature = "physics_avian")]
+    app.add_plugins(avian3d::prelude::PhysicsPlugins::default());
+
+    app.run();
+}
+
+const BOUNCE_POS: Vec3 = Vec3 {
+    x: 2.,
+    y: -2.4,
+    z: -2.,
+};
+
+const BALL_RADIUS: f32 = 0.5;
+
+/// set up a simple 3D scene
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // spawn text
+    commands.spawn((
+        Text("Press Space to toggle slow motion".to_string()),
+        TextFont {
+            font_size: 40.0,
+            ..default()
+        },
+        TextColor(Color::WHITE),
+        Transform::from_xyz(-4.0, 4.0, 0.0),
+    ));
+
+    // base
+    commands.run_system_cached_with(spawn_wall, (Vec3::new(0., -3., 0.), Vec3::new(8., 1., 8.)));
+    // walls
+    commands.run_system_cached_with(spawn_wall, (Vec3::new(-4., 0., 0.), Vec3::new(1., 6., 8.)));
+    commands.run_system_cached_with(spawn_wall, (Vec3::new(4., 0., 0.), Vec3::new(1., 6., 8.)));
+    commands.run_system_cached_with(spawn_wall, (Vec3::new(0., 0., -4.), Vec3::new(8., 6., 1.)));
+    commands.run_system_cached_with(spawn_wall, (Vec3::new(0., 0., 4.), Vec3::new(8., 6., 1.)));
+
+    // bouncing ball
+    commands
+        .spawn((
+            Mesh3d(meshes.add(Sphere::new(BALL_RADIUS))),
+            MeshMaterial3d(materials.add(Color::LinearRgba(LinearRgba::rgb(0.85, 0.1, 0.2)))),
+            Transform::from_translation(Vec3::new(0., 3., 0.)),
+            Collider::sphere(BALL_RADIUS),
+            RigidBody::Dynamic,
+            LinearVelocity(Vec3::new(8., 0., 6.)),
+            Friction::ZERO,
+            Restitution {
+                coefficient: 1.,
+                ..default()
+            },
+            CollisionEventsEnabled,
+        ))
+        .observe(
+            |trigger: Trigger<OnCollisionStart>,
+             mut commands: Commands,
+             collisions: Collisions,
+             collider: Query<(&Position, &Rotation)>| {
+                collisions
+                    .collisions_with(trigger.collider)
+                    .for_each(|pair| {
+                        let (impulse, mut normal) = pair.max_normal_impulse();
+                        if pair.collider1 != trigger.collider {
+                            normal = -normal;
+                        }
+
+                        let Ok((position, rotation)) = collider.get(trigger.collider) else {
+                            return;
+                        };
+                        let translation = pair.find_deepest_contact().map_or(Vec3::ZERO, |c| {
+                            if pair.collider1 == trigger.collider {
+                                c.global_point1(position, rotation)
+                            } else {
+                                c.global_point2(position, rotation)
+                            }
+                        });
+
+                        commands.spawn((
+                            ParticleSpawner {
+                                one_shot: true,
+                                rate: 20.,
+                                emission_shape: EmissionShape::Circle {
+                                    normal: Vec3::Y,
+                                    radius: 0.4,
+                                },
+                                lifetime: RandF32::constant(2.5),
+                                inherit_parent_velocity: true,
+                                initial_velocity: RandVec3 {
+                                    direction: Vec3::Y,
+                                    magnitude: RandF32 { min: 0., max: 2. },
+                                    spread: 0.,
+                                },
+                                initial_velocity_radial: RandF32 { min: 0., max: 2.5 },
+                                initial_scale: RandF32 {
+                                    min: (impulse / 10. - 0.1).max(0.),
+                                    max: (impulse / 10. + 0.1).min(1.),
+                                },
+                                scale_curve: FireworkCurve::even_samples(vec![1., 2.]),
+                                color: FireworkGradient::uneven_samples(vec![
+                                    (0., LinearRgba::new(0.6, 0.3, 0., 0.)),
+                                    (0.1, LinearRgba::new(0.6, 0.3, 0., 0.35)),
+                                    (1., LinearRgba::new(0.6, 0.3, 0., 0.0)),
+                                ]),
+                                blend_mode: BlendMode::Blend,
+                                linear_drag: 0.7,
+                                pbr: true,
+                                acceleration: Vec3::new(0., -1.5, 0.),
+                                fade_scene: 3.5,
+                                spawn_transform_mode: SpawnTransformMode::Local,
+                                ..default()
+                            },
+                            Transform {
+                                translation,
+                                rotation: Quat::from_rotation_arc(Vec3::Y, normal),
+                                ..default()
+                            },
+                        ));
+                    });
+            },
+        );
+
+    // light
+    commands.spawn((
+        PointLight {
+            intensity: 1500000.0,
+            shadows_enabled: true,
+            ..default()
+        },
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
+
+    // camera
+    commands.spawn((
+        Camera3d::default(),
+        Camera {
+            hdr: true,
+            ..default()
+        },
+        Transform::from_xyz(-2.5, 10., 4.0).looking_at(Vec3::new(0., -3., 0.), Vec3::Y),
+        Bloom::default(),
+        DepthPrepass::default(),
+        // For now,Msaa must be disabled on the web due to this:
+        // https://github.com/gfx-rs/wgpu/issues/5263
+        #[cfg(target_arch = "wasm32")]
+        Msaa::Off,
+    ));
+}
+
+fn spawn_wall(
+    In((center, size)): In<(Vec3, Vec3)>,
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::from_size(size))),
+        MeshMaterial3d(materials.add(Color::WHITE)),
+        Transform {
+            translation: center,
+            ..default()
+        },
+        Collider::cuboid(size.x, size.y, size.z),
+        RigidBody::Static,
+        Friction::ZERO,
+        Restitution {
+            coefficient: 1.,
+            ..default()
+        },
+    ));
+}
+
+fn rotate_point_light(mut point_lights: Query<&mut Transform, With<PointLight>>, time: Res<Time>) {
+    for mut transform in &mut point_lights {
+        transform.translation = Vec3::new(
+            4. * time.elapsed_secs().sin(),
+            8. * ((time.elapsed_secs() * 0.78932).sin() + 1.) / 2.,
+            4. * time.elapsed_secs().cos(),
+        );
+    }
+}
+
+fn adjust_time_scale(
+    mut slowmo: Local<bool>,
+    mut time: ResMut<Time<Virtual>>,
+    input: Res<ButtonInput<KeyCode>>,
+) {
+    if input.just_pressed(KeyCode::Space) {
+        *slowmo = !*slowmo;
+    }
+
+    if *slowmo {
+        time.set_relative_speed(0.05);
+    } else {
+        time.set_relative_speed(1.0);
+    }
+}

--- a/src/core.rs
+++ b/src/core.rs
@@ -158,6 +158,8 @@ impl std::fmt::Debug for ParticleCollisionSettings {
 
 #[derive(Component, Default)]
 pub struct ParticleSpawnerData {
+    /// Whether this particle system has already been initialized from the settings.
+    // NOTE: This won't be needed once we have `Construct`
     pub initialized: bool,
     pub enabled: bool,
     pub cooldown: Timer,
@@ -202,6 +204,7 @@ pub fn sync_spawner_data(
         data.cooldown.set_mode(TimerMode::Repeating);
         if !data.initialized {
             data.enabled = settings.starts_enabled;
+            data.initialized = true;
         }
     }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -12,13 +12,22 @@ use avian3d::prelude::*;
 pub const DEFAULT_MESH: Handle<Mesh> = weak_handle!("ba671aee-04f4-485d-9d1e-ad7053dacfab");
 
 /// Mirrors AlphaMode, but implements serialize and deserialize
-#[derive(Debug, Clone, Copy, PartialEq, Reflect, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect, Serialize, Deserialize)]
 pub enum BlendMode {
     Opaque,
     Blend,
     Premultiplied,
     Add,
     Multiply,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Reflect, Serialize, Deserialize)]
+pub enum SpawnTransformMode {
+    /// Use `GlobalTransform` to determine the initial position of spawned particles
+    #[default]
+    Global,
+    /// Use `Transform` to determine the initial position of spawned particles
+    Local,
 }
 
 impl From<BlendMode> for AlphaMode {
@@ -96,6 +105,8 @@ pub struct ParticleSpawner {
     pub collision_settings: Option<ParticleCollisionSettings>,
     /// Whether to initialize the spawner in an enabled state
     pub starts_enabled: bool,
+    /// Determines how to compute the initial position of the spawned particles
+    pub spawn_transform_mode: SpawnTransformMode,
 }
 
 impl Default for ParticleSpawner {
@@ -120,6 +131,7 @@ impl Default for ParticleSpawner {
             fade_edge: 0.7,
             fade_scene: 1.,
             starts_enabled: true,
+            spawn_transform_mode: default(),
         }
     }
 }
@@ -196,6 +208,7 @@ pub fn sync_spawner_data(
 
 pub fn spawn_particles(
     mut particle_systems_query: Query<(
+        &Transform,
         &GlobalTransform,
         &ParticleSpawner,
         &mut ParticleSpawnerData,
@@ -203,7 +216,9 @@ pub fn spawn_particles(
     )>,
     time: Res<Time>,
 ) {
-    for (global_transform, settings, mut data, opt_modifier) in &mut particle_systems_query {
+    for (transform, global_transform, settings, mut data, opt_modifier) in
+        &mut particle_systems_query
+    {
         if data.enabled {
             data.cooldown.tick(time.delta());
 
@@ -216,7 +231,11 @@ pub fn spawn_particles(
             };
 
             let modifier = opt_modifier.cloned().unwrap_or_default();
-            let origin = global_transform.compute_transform();
+
+            let origin = match settings.spawn_transform_mode {
+                SpawnTransformMode::Global => global_transform.compute_transform(),
+                SpawnTransformMode::Local => *transform,
+            };
 
             for _ in 0..particles_to_spawn {
                 let spawn_offset = settings.emission_shape.generate_point();


### PR DESCRIPTION
Fixes #30 by adding a `spawn_transform_mode` setting to particle systems. If set to `SpawnTransformMode::Local`, new particles will be spawned using the particle system's `Transform` component rather than `GlobalTransform`.

This PR also adds a new `one_shot` example to demonstrate spawning one-shot systems on Avian physics collisions.